### PR TITLE
Set up pipeline

### DIFF
--- a/.github/workflows/Full Pipe.yml
+++ b/.github/workflows/Full Pipe.yml
@@ -67,8 +67,8 @@ jobs:
       - name: Build to GitHub Container Registry
         # use jib plugin to build docker image
         run: >
-        mvn compile
-        com.google.cloud.tools:jib-maven-plugin:3.1.4:build
-        -Djib.to.image=ghcr.io/the-microservice-dungeon/gamelog/gamelogservice
-        -Djib.from.image=eclipse-temurin:17-alpine
+          mvn compile
+          com.google.cloud.tools:jib-maven-plugin:3.1.4:build
+          -Djib.to.image=ghcr.io/the-microservice-dungeon/gamelog/gamelogservice
+          -Djib.from.image=eclipse-temurin:17-alpine
 

--- a/.github/workflows/Full Pipe.yml
+++ b/.github/workflows/Full Pipe.yml
@@ -1,0 +1,68 @@
+name: CI/Image
+
+# Controls when the workflow will run
+on:
+  push:
+    paths-ignore:
+      - 'docs/**'
+      - 'swagger/**'
+      - '**/README.md'
+      - '**/.gitignore'
+    branches:
+      - 'main'
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  test:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: true
+          MYSQL_HOST: mysql
+          MYSQL_DATABASE: gamelog
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      - name: Setup JDK 11 + cache
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          # setup maven cache as well
+          cache: maven
+      - name: Unit-Test
+        env:
+          DB_HOST: localhost:3306
+          DB_PASSWORD: ''
+          DB_USER: root
+          DB_NAME: gamelog
+        run: mvn test -Psurefire
+  build-image:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup JDK 11 + cache
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          # setup maven cache as well
+          cache: maven
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build to GitHub Container Registry
+        # use jib plugin to build docker image
+        run: mvn compile com.google.cloud.tools:jib-maven-plugin:3.1.4:build -Dimage=ghcr.io/the-microservice-dungeon/gamelog/gamelogservice

--- a/.github/workflows/Full Pipe.yml
+++ b/.github/workflows/Full Pipe.yml
@@ -10,6 +10,7 @@ on:
       - '**/.gitignore'
     branches:
       - 'main'
+      - 'devops'
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
@@ -31,10 +32,10 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
-      - name: Setup JDK 11 + cache
+      - name: Setup JDK 17 + cache
         uses: actions/setup-java@v2
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           # setup maven cache as well
           cache: maven
@@ -50,10 +51,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Setup JDK 11 + cache
+      - name: Setup JDK 17 + cache
         uses: actions/setup-java@v2
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           # setup maven cache as well
           cache: maven
@@ -65,4 +66,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build to GitHub Container Registry
         # use jib plugin to build docker image
-        run: mvn compile com.google.cloud.tools:jib-maven-plugin:3.1.4:build -Dimage=ghcr.io/the-microservice-dungeon/gamelog/gamelogservice
+        run: >
+        mvn compile
+        com.google.cloud.tools:jib-maven-plugin:3.1.4:build
+        -Djib.to.image=ghcr.io/the-microservice-dungeon/gamelog/gamelogservice
+        -Djib.from.image=eclipse-temurin:17-alpine
+

--- a/.github/workflows/Full Pipe.yml
+++ b/.github/workflows/Full Pipe.yml
@@ -9,6 +9,7 @@ on:
       - '**/README.md'
       - '**/.gitignore'
     branches:
+      - 'devops'
       - 'main'
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/Full Pipe.yml
+++ b/.github/workflows/Full Pipe.yml
@@ -9,7 +9,6 @@ on:
       - '**/README.md'
       - '**/.gitignore'
     branches:
-      - 'devops'
       - 'main'
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/Full Pipe.yml
+++ b/.github/workflows/Full Pipe.yml
@@ -10,7 +10,7 @@ on:
       - '**/.gitignore'
     branches:
       - 'main'
-      - 'devops'
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"

--- a/.github/workflows/Unit Test.yml
+++ b/.github/workflows/Unit Test.yml
@@ -1,4 +1,4 @@
-name: CI Something Test
+name: CI Unit Test
 
 # Controls when the workflow will run
 on:

--- a/.github/workflows/Unit Test.yml
+++ b/.github/workflows/Unit Test.yml
@@ -1,0 +1,58 @@
+name: CI Something Test
+
+# Controls when the workflow will run
+on:
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - 'swagger/**'
+      - '**/README.md'
+      - '**/.gitignore'
+    branches:
+      - 'main'
+    # This workflow executes every time a pull request is opened,
+    # or if there are changes to the current pull request
+    types:
+      [synchronize,opened]
+  # Also if you push on devops
+  push:
+    paths-ignore:
+      - 'swagger/**'
+      - '**/README.md'
+      - '**/.gitignore'
+    branches:
+      - 'devops'
+      # A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  test:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: true
+          MYSQL_HOST: mysql
+          MYSQL_DATABASE: gamelog
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup JDK 11 + cache
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          # setup maven cache as well
+          cache: maven
+      - name: Unit-Test
+        env:
+          DB_HOST: localhost:3306
+          DB_PASSWORD: ''
+          DB_USER: root
+          DB_NAME: gamelog
+        run: mvn test -Psurefire

--- a/.github/workflows/Unit Test.yml
+++ b/.github/workflows/Unit Test.yml
@@ -33,10 +33,10 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - uses: actions/checkout@v2
-      - name: Setup JDK 11 + cache
+      - name: Setup JDK 17 + cache
         uses: actions/setup-java@v2
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           # setup maven cache as well
           cache: maven

--- a/.github/workflows/Unit Test.yml
+++ b/.github/workflows/Unit Test.yml
@@ -14,15 +14,6 @@ on:
     # or if there are changes to the current pull request
     types:
       [synchronize,opened]
-  # Also if you push on devops
-  push:
-    paths-ignore:
-      - 'swagger/**'
-      - '**/README.md'
-      - '**/.gitignore'
-    branches:
-      - 'devops'
-      # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
   test:

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,42 @@
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
 	</dependencies>
+	<!-- These are Build profiles for running unit and integration tests !-->
+
+	<profiles>
+		<profile>
+			<id>surefire</id>
+			<build>
+				<plugins>
+					<plugin>
+						<artifactId>maven-surefire-plugin</artifactId>
+						<version>2.22.2</version>
+						<configuration>
+							<excludes>
+								<exclude>**/*IntegrationTest.java</exclude>
+							</excludes>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<id>failsafe</id>
+			<build>
+				<plugins>
+					<plugin>
+						<artifactId>maven-failsafe-plugin</artifactId>
+						<version>2.22.2</version>
+						<configuration>
+							<includes>
+								<include>**/*IntegrationTest.java</include>
+							</includes>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 
 	<build>
 		<plugins>
@@ -110,5 +146,4 @@
 			</plugin>
 		</plugins>
 	</build>
-
 </project>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,7 +11,7 @@ logging.level.org.apache.kafka = WARN
 spring.jpa.database-platform=org.hibernate.dialect.MySQL5Dialect
 spring.datasource.password=${DB_PASSWORD}
 spring.datasource.username=${DB_USER}
-spring.datasource.url=jdbc:mysql://${DB_HOST:localhost:3306}/${DB_NAME}
+spring.datasource.url=jdbc:mysql://${DB_HOST}/${DB_NAME}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 # The Microservice Dungeon Configuration properties

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,7 +11,7 @@ logging.level.org.apache.kafka = WARN
 spring.jpa.database-platform=org.hibernate.dialect.MySQL5Dialect
 spring.datasource.password=${DB_PASSWORD}
 spring.datasource.username=${DB_USER}
-spring.datasource.url=jdbc:mysql://${DB_HOST}/${DB_NAME}
+spring.datasource.url=jdbc:mysql://${DB_HOST:localhost:3306}/${DB_NAME}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 # The Microservice Dungeon Configuration properties

--- a/src/test/java/com/github/tmd/gamelog/MyIntegrationTest.java
+++ b/src/test/java/com/github/tmd/gamelog/MyIntegrationTest.java
@@ -1,0 +1,21 @@
+package com.github.tmd.gamelog;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+/**
+ * This is the naming convention for integration tests
+ * Unit tests are run using the maven failsafe plugin.
+ * Either by using the command line: mvn test -Pfailsafe
+ * or clicking on the task failsafe:integration-test in the maven menu.
+ * Make sure you configure your environment variables (Through maven runner or system)
+ */
+@Disabled
+@SpringBootTest
+public class MyIntegrationTest {
+    @Test
+    public void myTestFunction(){
+        assert true;
+    }
+}

--- a/src/test/java/com/github/tmd/gamelog/MyUnitTest.java
+++ b/src/test/java/com/github/tmd/gamelog/MyUnitTest.java
@@ -1,0 +1,21 @@
+package com.github.tmd.gamelog;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+/**
+ * This is the naming convention for unit tests
+ * Unit tests are run using the maven surefire plugin.
+ * Either by using the command line: mvn test -Psurefire
+ * or clicking on the task surefire:test in the maven menu.
+ * Make sure you configure your environment variables (Through maven runner or system)
+ */
+@Disabled
+@SpringBootTest
+public class MyUnitTest {
+    @Test
+    public void myTestFunction(){
+        assert true;
+    }
+}


### PR DESCRIPTION
This includes a pipeline to run unit tests and build a docker image to the container registry.
Since this repository doesnt have any tests, I included two (now disabled) tests to demonstrate the naming convention and how you can execute them.
I had to modify the application.properties file to comply with the specification (DB_HOST with port number).

The unit test workflow will be executed on pull requests against the main branch, whereas the full pipe will only execute on pushes to main.